### PR TITLE
Add branch-$timestamp tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -78,7 +78,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ inputs.image_name || env.IMAGE_NAME }}
           tags: |
             type=schedule
-            type=schedule,pattern={{branch}}-{{date 'X'}}
+            type=schedule,pattern=${{github.ref_name}}-{{date 'X'}}
             type=ref,event=branch
             type=ref,event=tag
             type=ref,event=pr

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -76,6 +76,13 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           images: ${{ env.REGISTRY }}/${{ inputs.image_name || env.IMAGE_NAME }}
+          tags: |
+            type=schedule
+            type=schedule,pattern={{branch}}-{{date 'X'}}
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=raw,value={{branch}}-{{date 'X'}},enable={{is_default_branch}}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -79,6 +79,7 @@ jobs:
           tags: |
             type=schedule
             type=schedule,pattern=${{github.ref_name}}-{{date 'X'}}
+            type=schedule,pattern=nightly-{{date 'X'}}
             type=ref,event=branch
             type=ref,event=tag
             type=ref,event=pr


### PR DESCRIPTION
The purpose is to allowing tracking the main branch while still having immutable tags (mutable tags get weird with K8S). Tools such as FluxCD can match the pattern and pull the latest main-$timestamp tag by automatically updating our K8S specs.